### PR TITLE
Port branch to latest firmware

### DIFF
--- a/application.fam
+++ b/application.fam
@@ -20,4 +20,5 @@ App(
     fap_description="WIP MagSpoof port using the RFID subsystem",
     fap_author="Zachary Weiss",
     fap_weburl="https://github.com/zacharyweiss/magspoof_flipper",
+    fap_libs=["assets"],
 )

--- a/helpers/mag_text_input.c
+++ b/helpers/mag_text_input.c
@@ -1,6 +1,6 @@
 #include "mag_text_input.h"
 #include <gui/elements.h>
-#include <assets_icons.h>
+#include <mag_icons.h>
 #include <furi.h>
 
 struct Mag_TextInput {

--- a/mag.c
+++ b/mag.c
@@ -231,14 +231,13 @@ void mag_text_input_callback(void* context) {
 
 void mag_show_loading_popup(void* context, bool show) {
     Mag* mag = context;
-    TaskHandle_t timer_task = xTaskGetHandle(configTIMER_SERVICE_TASK_NAME);
 
     if(show) {
         // Raise timer priority so that animations can play
-        vTaskPrioritySet(timer_task, configMAX_PRIORITIES - 1);
+        furi_timer_set_thread_priority(FuriTimerThreadPriorityElevated);
         view_dispatcher_switch_to_view(mag->view_dispatcher, MagViewLoading);
     } else {
         // Restore default timer priority
-        vTaskPrioritySet(timer_task, configTIMER_TASK_PRIORITY);
+        furi_timer_set_thread_priority(FuriTimerThreadPriorityNormal);
     }
 }

--- a/scenes/mag_scene_input_name.c
+++ b/scenes/mag_scene_input_name.c
@@ -1,4 +1,4 @@
-#include <lib/toolbox/random_name.h>
+#include <toolbox/name_generator.h>
 #include "../mag_i.h"
 
 void mag_scene_input_name_on_enter(void* context) {
@@ -13,7 +13,7 @@ void mag_scene_input_name_on_enter(void* context) {
 
     if(name_is_empty) {
         furi_string_set(mag->file_path, MAG_APP_FOLDER);
-        set_random_name(mag->text_store, MAG_TEXT_STORE_SIZE);
+        name_generator_make_auto(mag->text_store, MAG_TEXT_STORE_SIZE, "prefix");
         furi_string_set(folder_path, MAG_APP_FOLDER);
     } else {
         // TODO: compatible types etc


### PR DESCRIPTION
From https://github.com/johanoskarsson

This PR fixes three build issues with the latest Flipper firwmare:

    Remove direct use of RTOS function and instead use new function for the same purpose
    Fix a build error re: icons/assets
    Replace use use of missing random_name.h file

This PR does not deal with the NFC refactor in the firmware however. (I just commented that out locally since I don't intend to use it).
